### PR TITLE
Version bump and npm publish request

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-eco",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Precompile ECO templates into JavaScript",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Right now npm retrieves a 3 month old version when npm cache is clean. Thus, version bump to 0.0.2, and could you also execute the "npm publish" command?

Cheers!
M.
